### PR TITLE
Build and upload docker image on pushes to `rancher-desktop` branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Build and upload container image
+on:
+  push:
+    branches: ['rancher-desktop']
+  workflow_dispatch: {}
+
+jobs:
+  linux-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Build Upgrade Responder
+        run: make
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: package
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,8 +28,8 @@ configMap:
 replicaCount: 3
 
 image:
-  repository: longhornio/upgrade-responder
-  tag: v0.1.5
+  repository: ghcr.io/rancher-sandbox/rancher-desktop-upgrade-responder
+  tag: thismustbeset
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Closes #3.

The uploaded docker image looks something like this:

`ghcr.io/rancher-sandbox/rancher-desktop-upgrade-responder:<commit>`

where `commit` is the full hash of the commit the image was derived from.