### PR TITLE
Make a couple of minor improvements to Upgrade Responder

### DIFF
--- a/rancherdesktop/responseConfig_test.go
+++ b/rancherdesktop/responseConfig_test.go
@@ -13,11 +13,11 @@ func TestResponseConfig(t *testing.T) {
 			responseConfig := ResponseConfig{
 				Versions: []Version{
 					{
-						Name:        "v1.2.3",
+						Name:        "1.2.3",
 						ReleaseDate: "2022-07-28T11:00:00Z",
 					},
 					{
-						Name:        "v2.3.4",
+						Name:        "2.3.4",
 						ReleaseDate: "2022-07-28T11:00:00Z",
 						Tags:        []string{"latest"},
 					},
@@ -40,11 +40,11 @@ func TestResponseConfig(t *testing.T) {
 				ResponseConfig: ResponseConfig{
 					Versions: []Version{
 						{
-							Name:        "v1.2.3",
+							Name:        "1.2.3",
 							ReleaseDate: "2022-07-28T11:00:00Z",
 						},
 						{
-							Name:        "v1.2.3",
+							Name:        "1.2.3",
 							ReleaseDate: "2022-07-28T11:00:00Z",
 						},
 					},
@@ -56,7 +56,7 @@ func TestResponseConfig(t *testing.T) {
 				ResponseConfig: ResponseConfig{
 					Versions: []Version{
 						{
-							Name:        "v1.2.3",
+							Name:        "1.2.3",
 							ReleaseDate: "2022-07-28T11:00:00Z",
 						},
 					},
@@ -68,12 +68,12 @@ func TestResponseConfig(t *testing.T) {
 				ResponseConfig: ResponseConfig{
 					Versions: []Version{
 						{
-							Name:        "v1.2.3",
+							Name:        "1.2.3",
 							ReleaseDate: "2022-07-28T11:00:00Z",
 							Tags:        []string{"latest"},
 						},
 						{
-							Name:        "v2.3.4",
+							Name:        "2.3.4",
 							ReleaseDate: "2022-07-28T11:00:00Z",
 							Tags:        []string{"latest"},
 						},

--- a/rancherdesktop/rule_test.go
+++ b/rancherdesktop/rule_test.go
@@ -300,7 +300,7 @@ func TestRule(t *testing.T) {
 				Description: "should return false for a version that does not satisfy the Version constraint",
 				Rule:        newRule(t, "*", "darwin", "*", "*", ">2.0.0"),
 				Version: Version{
-					Name:        "v1.2.3",
+					Name:        "1.2.3",
 					ReleaseDate: "2022-07-28T11:00:00Z",
 				},
 				ExpectedReturn: false,
@@ -309,7 +309,7 @@ func TestRule(t *testing.T) {
 				Description: "should return true for a version that satisfies the Version constraint",
 				Rule:        newRule(t, "*", "darwin", "*", "*", "<2.0.0"),
 				Version: Version{
-					Name:        "v1.2.3",
+					Name:        "1.2.3",
 					ReleaseDate: "2022-07-28T11:00:00Z",
 				},
 				ExpectedReturn: true,

--- a/rancherdesktop/testdata/test-config.json
+++ b/rancherdesktop/testdata/test-config.json
@@ -25,17 +25,17 @@
   ],
   "Versions": [
     {
-      "Name": "v1.2.3",
+      "Name": "1.2.3",
       "ReleaseDate": "2022-07-28T11:00:00Z",
       "Tags": []
     },
     {
-      "Name": "v2.3.4",
+      "Name": "2.3.4",
       "ReleaseDate": "2022-07-28T11:00:00Z",
       "Tags": []
     },
     {
-      "Name": "v4.5.6",
+      "Name": "4.5.6",
       "ReleaseDate": "2022-07-28T11:00:00Z",
       "Tags": [
         "latest"

--- a/rancherdesktop/version.go
+++ b/rancherdesktop/version.go
@@ -22,7 +22,7 @@ type Version struct {
 
 // Validate is used to check whether a Version is valid.
 func (version *Version) Validate() error {
-	if _, err := semver.NewVersion(version.Name); err != nil {
+	if _, err := semver.StrictNewVersion(version.Name); err != nil {
 		return fmt.Errorf("failed to parse Name: %w", err)
 	}
 	if _, err := time.Parse(time.RFC3339, version.ReleaseDate); err != nil {

--- a/rancherdesktop/version_test.go
+++ b/rancherdesktop/version_test.go
@@ -11,7 +11,7 @@ func TestVersion(t *testing.T) {
 
 		t.Run("should return nil for a valid version", func(t *testing.T) {
 			version := Version{
-				Name:        "v1.2.3",
+				Name:        "1.2.3",
 				ReleaseDate: "2022-07-28T11:00:00Z",
 			}
 			err := version.Validate()
@@ -27,7 +27,7 @@ func TestVersion(t *testing.T) {
 			ExpectedError string
 		}{
 			{
-				Description: "should return error if Version.Name is not valid semver",
+				Description: "should return error if Version.Name is not close to valid semver",
 				Version: Version{
 					Name:        "invalidSemver",
 					ReleaseDate: "2022-07-28T11:00:00Z",
@@ -35,9 +35,25 @@ func TestVersion(t *testing.T) {
 				ExpectedError: "failed to parse Name",
 			},
 			{
-				Description: "should return error if Version.ReleaseDate is not in RFC3339 format",
+				Description: "should return error if Version.Name starts with a v",
 				Version: Version{
 					Name:        "v1.2.3",
+					ReleaseDate: "2022-07-28T11:00:00Z",
+				},
+				ExpectedError: "failed to parse Name",
+			},
+			{
+				Description: "should return error if Version.Name has only two dot-separated sections",
+				Version: Version{
+					Name:        "1.2",
+					ReleaseDate: "2022-07-28T11:00:00Z",
+				},
+				ExpectedError: "failed to parse Name",
+			},
+			{
+				Description: "should return error if Version.ReleaseDate is not in RFC3339 format",
+				Version: Version{
+					Name:        "1.2.3",
 					ReleaseDate: "notValidRFC3339",
 				},
 				ExpectedError: "failed to parse ReleaseDate",

--- a/upgraderesponder/service.go
+++ b/upgraderesponder/service.go
@@ -257,7 +257,7 @@ func (s *Server) GenerateCheckUpgradeResponse(request rd.CheckUpgradeRequest) (*
 		logrus.Debugf("could not parse request %+v as InstanceInfo: %s", request, err)
 		resp.Versions = s.DefaultVersions
 	} else {
-		logrus.Debugf("parsed request into InstanceInfo %+v: %s", request, err)
+		logrus.Debugf("parsed request into InstanceInfo %+v", request)
 		for _, precomp := range s.PrecomputedVersions {
 			if precomp.Rule.AppliesTo(instanceInfo) {
 				resp.Versions = precomp.Versions

--- a/upgraderesponder/service_test.go
+++ b/upgraderesponder/service_test.go
@@ -44,7 +44,7 @@ func TestServer(t *testing.T) {
 		t.Run("all Version.Supported should be true when request cannot be parsed to InstanceInfo", func(t *testing.T) {
 			server := getTestServer(t, testConfig)
 			checkUpgradeRequest := rd.CheckUpgradeRequest{
-				AppVersion: "v1.2.3",
+				AppVersion: "1.2.3",
 				ExtraInfo: map[string]string{
 					"platform": "darwin-x64",
 				},
@@ -62,7 +62,7 @@ func TestServer(t *testing.T) {
 		t.Run("all Version.Supported should be true when request does not match any Rules", func(t *testing.T) {
 			server := getTestServer(t, testConfig)
 			checkUpgradeRequest := rd.CheckUpgradeRequest{
-				AppVersion: "v2.0.0",
+				AppVersion: "2.0.0",
 				ExtraInfo: map[string]string{
 					"platform":        "darwin-x64",
 					"platformVersion": "12.0.3",
@@ -124,7 +124,7 @@ func TestServer(t *testing.T) {
 			}
 			server := getTestServer(t, config)
 			checkUpgradeRequest := rd.CheckUpgradeRequest{
-				AppVersion: "v1.0.0",
+				AppVersion: "1.0.0",
 				ExtraInfo: map[string]string{
 					"platform":        "darwin-x64",
 					"platformVersion": "12.0.3",

--- a/upgraderesponder/testdata/same-constraint-config.json
+++ b/upgraderesponder/testdata/same-constraint-config.json
@@ -25,17 +25,17 @@
   ],
   "Versions": [
     {
-      "Name": "v1.2.3",
+      "Name": "1.2.3",
       "ReleaseDate": "2022-07-28T11:00:00Z",
       "Tags": []
     },
     {
-      "Name": "v2.3.4",
+      "Name": "2.3.4",
       "ReleaseDate": "2022-07-28T11:00:00Z",
       "Tags": []
     },
     {
-      "Name": "v4.5.6",
+      "Name": "4.5.6",
       "ReleaseDate": "2022-07-28T11:00:00Z",
       "Tags": [
         "latest"


### PR DESCRIPTION
This PR does two things:

1. Fixes a confusing log message which printed an error when that error was always `nil`.
2. Uses `StrictNewVersion` rather than `NewVersion`, which requires that versions passed in the response config strictly adhere to semver. This means no `v`s, there must be at minimum three dot-separated numbers, et cetera.